### PR TITLE
Fix: image tensor normalization

### DIFF
--- a/dog_app.ipynb
+++ b/dog_app.ipynb
@@ -465,7 +465,7 @@
     "        img = image.load_img(img_path, target_size=(224, 224))\n",
     "        x = image.img_to_array(img)\n",
     "        # Normalize the image tensor\n",
-    "        return np.expand_dims(x, axis=0).astype('float32')/255\n",
+    "        return np.expand_dims(x, axis=0)#.astype('float32')/255\n",
     "    except IOError:\n",
     "        print(f\"Warning: Skipping corrupted image {img_path}\")\n",
     "        return None\n",
@@ -498,7 +498,7 @@
    "source": [
     "img = image.load_img(dog_files_short[0], target_size=(224, 224))\n",
     "x = image.img_to_array(img)\n",
-    "(np.expand_dims(x, axis=0).astype('float32')/255).shape"
+    "(np.expand_dims(x, axis=0)).shape #.astype('float32')/255)"
    ]
   },
   {


### PR DESCRIPTION
Due to the normalization of image tensor, the prediction range was alleviated for the dog images and hence, you were getting the 0% prediction in the dog detector.